### PR TITLE
Added "ASP" file type and corrected spelling

### DIFF
--- a/grammars/vbscript.cson
+++ b/grammars/vbscript.cson
@@ -1,10 +1,11 @@
 'comment': 'based on asp textmate bundle by Rich Barton'
 'fileTypes': [
+  'asp',
   'vbs',
   'vb',
   'vba'
 ]
-'name': 'VBScipt'
+'name': 'VBScript'
 'patterns': [
   {
     'captures':


### PR DESCRIPTION
Prompted by #1. Confirmed working in Atom 0.127.0 on Windows 8.1.

![vbscript](https://cloud.githubusercontent.com/assets/608191/4244681/15b56840-3a26-11e4-81c1-a5d78304b0b0.png)
