### PR TITLE
use apostrophe for toggle comments

### DIFF
--- a/settings/language-vbscript.cson
+++ b/settings/language-vbscript.cson
@@ -1,3 +1,4 @@
 '.source.vbs':
   'editor':
+    'commentStart': "' "
     'foldEndPattern': '(?i)^\\s*End (Class|Function|Sub|Property)\\s*$'


### PR DESCRIPTION
Modified settings/language-vbscript.cson to use a leading apostrophe when toggling VB comments.